### PR TITLE
Load param names from ENV variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ playground.go
 
 # e2e tests
 scripts/e2e_test/
+
+# generated log files
+*.log

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ This will start fee oracle service, ganache-cli locally, install `solcjs`, `abig
 
 # EVN Params
 Fee oracle loads important configs and prikey from files in CLI flags; however, the following EVN params will suppress CLI flags if provided.  
-Note: if `REMOTE_PARAM_OPERATOR_ENABLE` is set to `true`, valid credentials of the remote service must be setup.
+Note: if `REMOTE_PARAM_OPERATOR_ENABLE` is set to `true`, valid credentials of the remote service must be setup. In addition `REMOTE_PARAM_DOMAIN_DATA` and `REMOTE_PARAM_RESOURCE_DATA` variables need to be set.
 ```text
 APP_MODE=release                                             // app mode: debug or release. app mode is used for internal testing only.
 IDENTITY_KEY=                                                // fee oracle prikey in hex, without 0x prefix 
@@ -195,6 +195,8 @@ MOONSCAN_API_KEY=                                            // api key of moons
 DATA_VALID_INTERVAL=3600                                     // Time of valid fee oracle response data in seconds
 CONVERSION_RATE_PAIRS=eth,usdt,matic,usdt                    // conversion rate pairs that enabled for price fetching. Must be paired
 REMOTE_PARAM_OPERATOR_ENABLE=true                            // enable remote param operator, only enable this when deploying to remote environment like staging or prod
+REMOTE_PARAM_DOMAIN_DATA="domainData/param/name"             // domain data remote parameter name 
+REMOTE_PARAM_RESOURCE_DATA="resourceData/param/name"         // resource data remote parameter name
 ```
 
 # API Documentation

--- a/config/config.go
+++ b/config/config.go
@@ -33,9 +33,6 @@ var (
 
 	AppModeRelease AppMode = "release"
 	AppModeDebug   AppMode = "debug"
-
-	remoteParamDomainData   = "/chainbridge/fee-oracle/domainData"
-	remoteParamResourceData = "/chainbridge/fee-oracle/resourceData"
 )
 
 type Config struct {
@@ -358,6 +355,10 @@ func (c *Config) SetRemoteParams(operator remoteParam.RemoteParamOperator) {
 		return
 	}
 
+	remoteParamDomainData := os.Getenv("REMOTE_PARAM_DOMAIN_DATA")
+	if remoteParamDomainData == "" {
+		panic(errors.New("empty REMOTE_PARAM_DOMAIN_DATA from env param"))
+	}
 	domains, err := c.remoteParamsLoad(operator, remoteParamDomainData)
 	if err != nil {
 		panic(err)
@@ -366,6 +367,10 @@ func (c *Config) SetRemoteParams(operator remoteParam.RemoteParamOperator) {
 		c.setDomains(domains)
 	}
 
+	remoteParamResourceData := os.Getenv("REMOTE_PARAM_RESOURCE_DATA")
+	if remoteParamResourceData == "" {
+		panic(errors.New("empty REMOTE_PARAM_RESOURCE_DATA from env param"))
+	}
 	resources, err := c.remoteParamsLoad(operator, remoteParamResourceData)
 	if err != nil {
 		panic(err)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -53,6 +53,9 @@ func (s *RemoteParamOperatorTestSuite) SetupTest() {
 
 func (s *RemoteParamOperatorTestSuite) TearDownTest() {
 	_ = s.appBase.GetStore().Close()
+
+	_ = os.Setenv("REMOTE_PARAM_DOMAIN_DATA", "")
+	_ = os.Setenv("REMOTE_PARAM_RESOURCE_DATA", "")
 }
 
 func (s *RemoteParamOperatorTestSuite) TestSetRemoteParams_operatorIsNil() {
@@ -60,9 +63,17 @@ func (s *RemoteParamOperatorTestSuite) TestSetRemoteParams_operatorIsNil() {
 	s.NotPanics(func() { s.conf.SetRemoteParams(nil) }, "should not panic")
 }
 
-func (s *RemoteParamOperatorTestSuite) TestSetRemoteParams_Failure() {
+func (s *RemoteParamOperatorTestSuite) TestSetRemoteParams_nonExistingParam_Failure() {
 	s.remoteParamOperator.EXPECT().LoadParameter("/chainbridge/fee-oracle/domainData").Return(nil, errors.New("error"))
+
+	_ = os.Setenv("REMOTE_PARAM_DOMAIN_DATA", "/chainbridge/fee-oracle/domainData")
+	_ = os.Setenv("REMOTE_PARAM_RESOURCE_DATA", "/chainbridge/fee-oracle/resourceData")
+
 	s.Panics(func() { s.conf.SetRemoteParams(s.remoteParamOperator) }, "should panic on non existing param name")
+}
+
+func (s *RemoteParamOperatorTestSuite) TestSetRemoteParams_paramNameNotSet_Failure() {
+	s.Panics(func() { s.conf.SetRemoteParams(s.remoteParamOperator) }, "should panic if params name not set")
 }
 
 func (s *RemoteParamOperatorTestSuite) TestSetRemoteParams_Success() {
@@ -96,6 +107,9 @@ func (s *RemoteParamOperatorTestSuite) TestSetRemoteParams_Success() {
 	// ]
 	//}
 	resourceData := "{\n\t \"resources\": [\n\t   {\n\t     \"id\": \"0x0000000000000000000000000000000000000000000000000000000000000001\",\n\t     \"symbol\": \"eth\",\n\t     \"decimal\": 18,\n\t     \"tokenAddress\": \"0xfC2e2618147813E510CFc92747f0D09C14A653c5\",\n\t     \"domainId\": 3\n\t   }\n\t ]\n\t}\n"
+
+	_ = os.Setenv("REMOTE_PARAM_DOMAIN_DATA", "/chainbridge/fee-oracle/domainData")
+	_ = os.Setenv("REMOTE_PARAM_RESOURCE_DATA", "/chainbridge/fee-oracle/resourceData")
 
 	s.remoteParamOperator.EXPECT().LoadParameter("/chainbridge/fee-oracle/domainData").Times(1).Return(&remoteParam.RemoteParamResult{Value: domainData}, nil)
 	s.remoteParamOperator.EXPECT().LoadParameter("/chainbridge/fee-oracle/resourceData").Times(1).Return(&remoteParam.RemoteParamResult{Value: resourceData}, nil)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Load ssm params names (domainData and resourceData) from ENV variables (`REMOTE_PARAM_DOMAIN_DATA` and `REMOTE_PARAM_RESOURCE_DATA`)

## Related Issue Or Context
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Otherwise, describe context and motivation for change herre -->

Closes: #13 

## How Has This Been Tested? Testing details.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have ensured that all acceptance criteria (or expected behavior) from issue are met
- [x] I have updated the documentation locally and in chainbridge-docs.
- [x] I have added tests to cover my changes.
- [ ] I have ensured that all the checks are passing and green, I've signed the CLA bot
